### PR TITLE
feat: upgrade GitHub Actions to support Node.js 24

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)"
+    ]
+  }
+}

--- a/.github/workflows/amd64-release.yml
+++ b/.github/workflows/amd64-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Pull Docker Images and Package
         run: |
@@ -36,7 +36,7 @@ jobs:
           echo "RELEASE_NAME=$release_name" >> $GITHUB_ENV
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@master
+        uses: softprops/action-gh-release@v2.2.0
         with:
           tag_name: DockerTarBuilder-AMD64
           name: ${{ env.RELEASE_NAME }} for x86-64
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Docker images as release assets
-        uses: softprops/action-gh-release@v2.1.0
+        uses: softprops/action-gh-release@v2.2.0
         with:
           tag_name: DockerTarBuilder-AMD64
           files: ${{ github.workspace }}/*.tar.gz

--- a/.github/workflows/amd64.yml
+++ b/.github/workflows/amd64.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Clean up Docker to free space
       run: |
@@ -34,7 +34,7 @@ jobs:
           done
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: my-artifact
         path: ${{ github.workspace }}/*.tar.gz

--- a/.github/workflows/arm32-release.yml
+++ b/.github/workflows/arm32-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Pull Docker Images and Package
         run: |
@@ -36,7 +36,7 @@ jobs:
           echo "RELEASE_NAME=$release_name" >> $GITHUB_ENV
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@master
+        uses: softprops/action-gh-release@v2.2.0
         with:
           tag_name: DockerTarBuilder-ARM32
           name: ${{ env.RELEASE_NAME }} for ARM32
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Docker images as release assets
-        uses: softprops/action-gh-release@v2.1.0
+        uses: softprops/action-gh-release@v2.2.0
         with:
           tag_name: DockerTarBuilder-ARM32
           files: ${{ github.workspace }}/*.tar.gz

--- a/.github/workflows/arm32.yml
+++ b/.github/workflows/arm32.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Pull Docker Images and Package
       run: |
@@ -30,7 +30,7 @@ jobs:
           done
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: my-artifact
         path: ${{ github.workspace }}/*.tar.gz

--- a/.github/workflows/arm64-release.yml
+++ b/.github/workflows/arm64-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Pull Docker Images and Package
         run: |
@@ -36,7 +36,7 @@ jobs:
           echo "RELEASE_NAME=$release_name" >> $GITHUB_ENV
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@master
+        uses: softprops/action-gh-release@v2.2.0
         with:
           tag_name: DockerTarBuilder-ARM64
           name: ${{ env.RELEASE_NAME }} for ARM64
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Docker images as release assets
-        uses: softprops/action-gh-release@v2.1.0
+        uses: softprops/action-gh-release@v2.2.0
         with:
           tag_name: DockerTarBuilder-ARM64
           files: ${{ github.workspace }}/*.tar.gz

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Pull Docker Images and Package
       run: |
@@ -30,7 +30,7 @@ jobs:
           done
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: my-artifact
         path: ${{ github.workspace }}/*.tar.gz


### PR DESCRIPTION
- Update actions/checkout from v4 to v6
- Update actions/upload-artifact from v4 to v7
- Update softprops/action-gh-release from master/v2.1.0 to v2.2.0